### PR TITLE
Feature/build and start process

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -6,7 +6,8 @@ const Net = require('net');
 // The port number and hostname of the server.
 const port = 6969;
 const host = "127.0.0.1";
-const end = "end";
+const endString = "end";
+const end = new Buffer.from(endString);
 const repo = "https://github.com/cs-24-pt-10-01/HotspotBenchmarkJS.git";
 
 const client = new Net.Socket();
@@ -20,7 +21,7 @@ client.connect({ port: port, host: host }, function () {
 });
 
 client.on('data', function (data) {
-    if (data.toString('utf-8').endsWith(end)) {
+    if (data.subarray(data.length - end.length).toString() == endString) {
         dataBuffer = Buffer.concat([dataBuffer, data]);
 
         const dataBufferString = dataBuffer.toString().slice(0, -end.length);

--- a/Client.js
+++ b/Client.js
@@ -7,6 +7,7 @@ const Net = require('net');
 const port = 6969;
 const host = "127.0.0.1";
 const end = "end";
+const repo = "https://github.com/cs-24-pt-10-01/HotspotBenchmarkJS.git";
 
 const client = new Net.Socket();
 
@@ -14,6 +15,7 @@ let dataBuffer = Buffer.alloc(0);
 
 client.connect({ port: port, host: host }, function () {
     client.write("1"); // indicating client stream
+    client.write(repo);
     console.log('Connected');
 });
 
@@ -34,6 +36,14 @@ client.on('data', function (data) {
     else {
         dataBuffer = Buffer.concat([dataBuffer, data]);
     }
+});
+
+client.on('error', function (err) {
+    console.log(err);
+});
+
+client.on('end', function () {
+    console.log('Disconnected');
 });
 
 // TODO fix json formatting, "[...],[...]" not allowed

--- a/crates/remote-client/src/main.rs
+++ b/crates/remote-client/src/main.rs
@@ -36,6 +36,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await
         .unwrap();
 
+    // signifying no repo
+    stream.write_all(b"none").await.unwrap();
+
     let file = OpenOptions::new()
         .append(true)
         .create(true)

--- a/crates/server/src/build.rs
+++ b/crates/server/src/build.rs
@@ -1,6 +1,6 @@
 use crate::component_def::Build;
 use std::fs::remove_dir_all;
-use std::process::{Command, Output};
+use std::process::Command;
 use std::{env, io};
 
 pub struct GitBuild {}

--- a/crates/server/src/build.rs
+++ b/crates/server/src/build.rs
@@ -3,9 +3,9 @@ use std::env;
 use std::fs::remove_dir_all;
 use std::process::Command;
 
-pub struct BuilderImplem {}
+pub struct GitBuild {}
 
-impl Build for BuilderImplem {
+impl Build for GitBuild {
     fn build(&self, repo: String) -> bool {
         let repo_name = repo.clone().split("/").last().unwrap().to_string();
         let repo_name = repo_name[0..repo_name.len() - 4].to_string(); // remove .git from end

--- a/crates/server/src/build.rs
+++ b/crates/server/src/build.rs
@@ -1,7 +1,7 @@
 use crate::component_def::Build;
 use std::env;
 use std::fs::remove_dir_all;
-use std::{process::Command, string};
+use std::process::Command;
 
 pub struct BuilderImplem {}
 
@@ -9,7 +9,6 @@ impl Build for BuilderImplem {
     fn build(&self, repo: String) -> bool {
         let repo_name = repo.clone().split("/").last().unwrap().to_string();
         let repo_name = repo_name[0..repo_name.len() - 4].to_string(); // remove .git from end
-        let repo_name_clone = repo_name.clone();
 
         //saving current directory
         let current_dir = env::current_dir().unwrap();
@@ -22,7 +21,7 @@ impl Build for BuilderImplem {
             .expect("failed to clone repo");
 
         // Change directory to the repo
-        env::set_current_dir(repo_name_clone.clone()).unwrap();
+        env::set_current_dir(repo_name.clone()).unwrap();
 
         // run script (run with bash for linux and powershell for windows)
         println!("starting process {}...", repo_name);

--- a/crates/server/src/build.rs
+++ b/crates/server/src/build.rs
@@ -1,10 +1,50 @@
 use crate::component_def::Build;
+use std::{process::Command, string};
 
 pub struct BuilderImplem {}
 
 impl Build for BuilderImplem {
-    fn build(&self, build_script: String) -> bool {
-        println!("building not implemented");
-        return false;
+    fn build(&self, repo: String) -> bool {
+        let repo_name = repo.clone().split("/").last().unwrap().to_string();
+        let repo_name = repo_name[0..repo_name.len() - 4].to_string(); // remove .git from end
+        let repo_name_clone = repo_name.clone();
+
+        // clone repo using git
+        Command::new("git")
+            .arg("clone")
+            .arg(repo)
+            .output()
+            .expect("failed to clone repo");
+
+        //TODO change env directory
+
+        // run script (run with bash for linux and powershell for windows)
+        println!("starting process");
+        if cfg!(target_os = "windows") {
+            Command::new("powershell")
+                .arg("./run.ps1")
+                .output()
+                .expect("failed to execute process");
+        } else {
+            Command::new("bash")
+                .arg("run.sh")
+                .output()
+                .expect("failed to execute process");
+        };
+        println!("process finished");
+
+        Command::new("cd")
+            .arg("..")
+            .output()
+            .expect("failed to move of folder??");
+
+        // clean up
+        Command::new("rm")
+            .arg("-rf")
+            .arg(repo_name_clone)
+            .output()
+            .expect("failed to remove repo");
+
+        true
     }
 }

--- a/crates/server/src/component_def.rs
+++ b/crates/server/src/component_def.rs
@@ -9,7 +9,7 @@ pub trait Measurement<T> {
 }
 
 pub trait Build {
-    fn build(&self, build_script: String) -> bool; // returns whether it succeded
+    fn build(&self, repo: String) -> bool; // returns whether it succeded
 }
 
 pub trait StartProcess {

--- a/crates/server/src/component_def.rs
+++ b/crates/server/src/component_def.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use anyhow::Result;
 
 pub trait Measurement<T> {
@@ -9,7 +11,7 @@ pub trait Measurement<T> {
 }
 
 pub trait Build {
-    fn build(&self, repo: String) -> bool; // returns whether it succeded
+    fn build(&self, repo: String) -> Result<(), io::Error>; // returns whether it succeded
 }
 
 pub trait StartProcess {

--- a/crates/server/src/listener.rs
+++ b/crates/server/src/listener.rs
@@ -133,22 +133,23 @@ async fn handle_remote_connection(
         return;
     }
 
+    // Thread for building and running process
     thread::spawn(move || {
         // build and start process
         let res = GitBuild {}.build(repo);
         match res {
             Ok(_) => {}
             Err(e) => {
-                println!("Failed to build repo: {:?}", e);
+                println!("Failed to build and run repo: {:?}", e);
             }
         }
 
         // waiting for measurements to be sent
-        while (!LOCAL_CLIENT_PACKET_QUEUE.is_empty()) {
+        while !LOCAL_CLIENT_PACKET_QUEUE.is_empty() {
             thread::sleep(Duration::from_secs(1));
         }
 
-        // Disconnecting client
+        // Disconnecting client measurement is done
         // TODO this can break with multiple clients are connected.
         match remote_tcpstreams.lock().unwrap().pop() {
             Some(s) => {

--- a/crates/server/src/listener.rs
+++ b/crates/server/src/listener.rs
@@ -135,7 +135,13 @@ async fn handle_remote_connection(
 
     thread::spawn(move || {
         // build and start process
-        GitBuild {}.build(repo);
+        let res = GitBuild {}.build(repo);
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                println!("Failed to build repo: {:?}", e);
+            }
+        }
 
         // waiting for measurements to be sent
         while (!LOCAL_CLIENT_PACKET_QUEUE.is_empty()) {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -30,6 +30,11 @@ fn main() {
 
     let build = BuilderImplem {};
 
+    // test
+    let yay = build.build(r#"https://github.com/cs-24-pt-10-01/HotspotBenchmarkJS.git"#.to_owned());
+    println!("yay: {}", yay);
+
+    /*
     let mut measure = RaplSampler::new(
         config.thor.max_sample_age_millis as u128,
         config.thor.sampling_interval_micros,
@@ -43,4 +48,5 @@ fn main() {
         remote_packet_queue_cycle: config.thor.remote_packet_queue_cycle_millis,
     };
     listen.start_listening(start, build, &mut measure).unwrap();
+    */
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -9,7 +9,7 @@ mod start_process;
 use crate::component_def::{Build, Listener, Measurement, StartProcess};
 
 // implementations of components
-use crate::build::BuilderImplem;
+use crate::build::GitBuild;
 use crate::listener::ListenerImplem;
 use crate::measurement::RaplSampler;
 use crate::start_process::StartImplem;
@@ -28,13 +28,10 @@ fn main() {
 
     let start = StartImplem {};
 
-    let build = BuilderImplem {};
+    let build = GitBuild {};
 
     // test
-    let yay = build.build(r#"https://github.com/cs-24-pt-10-01/HotspotBenchmarkJS.git"#.to_owned());
-    println!("yay: {}", yay);
 
-    /*
     let mut measure = RaplSampler::new(
         config.thor.max_sample_age_millis as u128,
         config.thor.sampling_interval_micros,
@@ -48,5 +45,4 @@ fn main() {
         remote_packet_queue_cycle: config.thor.remote_packet_queue_cycle_millis,
     };
     listen.start_listening(start, build, &mut measure).unwrap();
-    */
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -30,8 +30,6 @@ fn main() {
 
     let build = GitBuild {};
 
-    // test
-
     let mut measure = RaplSampler::new(
         config.thor.max_sample_age_millis as u128,
         config.thor.sampling_interval_micros,


### PR DESCRIPTION
Things done:
- Implemented build from git, where the client is expected to send a string containing either:
   - link to repo
   - "none" for just observing
- Disconnecting clients after repo has been build and executed (and all measurements are send)
   - This is an indication to the client that the measurement is done.
- Disconnecting clients that cant accept data
- Some error handling